### PR TITLE
Filter meals

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,8 @@ python manage.py createsuperuser
 ```
 python manage.py runserver
 ```
+
+### Seed test data
+```
+python manage.py seed_meals
+```

--- a/meals/dates.py
+++ b/meals/dates.py
@@ -9,16 +9,28 @@ def next_day(date):
     return date + datetime.timedelta(days=1)
 
 
+def day_of_week(date=today()):
+    num = date.weekday()
+    if num == 6:
+        return 0
+    else:
+        return num + 1
+
+
 def start_of_week(date=today()):
-    return date - datetime.timedelta(days=date.weekday() + 1)
+    return date - datetime.timedelta(days=day_of_week(date))
+
+
+def end_of_week(date=today()):
+    return start_of_week(date) + datetime.timedelta(days=6)
 
 
 def previous_week(date=start_of_week()):
     return date - datetime.timedelta(weeks=1)
 
 
-def end_of_week(date=today()):
-    return start_of_week(date) + datetime.timedelta(days=6)
+def next_week(date=start_of_week()):
+    return date + datetime.timedelta(weeks=1)
 
 
 def week_range(date=today()):

--- a/meals/dates.py
+++ b/meals/dates.py
@@ -1,0 +1,25 @@
+import datetime
+
+
+def today():
+    return datetime.date.today()
+
+
+def next_day(date=today()):
+    return date + datetime.timedelta(days=1)
+
+
+def start_of_week(date=today()):
+    return date - datetime.timedelta(days=date.weekday() + 1)
+
+
+def previous_week(date=start_of_week()):
+    return date - datetime.timedelta(weeks=1)
+
+
+def end_of_week(date=today()):
+    return start_of_week(date) + datetime.timedelta(days=6)
+
+
+def week_range(date=today()):
+    return [start_of_week(date), end_of_week(date)]

--- a/meals/dates.py
+++ b/meals/dates.py
@@ -5,7 +5,7 @@ def today():
     return datetime.date.today()
 
 
-def next_day(date=today()):
+def next_day(date):
     return date + datetime.timedelta(days=1)
 
 

--- a/meals/management/commands/seed_meals.py
+++ b/meals/management/commands/seed_meals.py
@@ -1,28 +1,23 @@
-import datetime
 import random
 
 from django.core.management.base import BaseCommand
 
 from meals.models import Meal, MealItem
+from meals.dates import previous_week, end_of_week, next_day
 
 
 class Command(BaseCommand):
     help = 'Inserts test data'
 
     def handle(self, *args, **options):
-        start_of_this_week = start_of_week()
-        start_of_next_week = start_of_this_week + datetime.timedelta(weeks=1)
+        date = previous_week()
+        end_date = end_of_week()
 
-        date = start_of_this_week - datetime.timedelta(weeks=1)
-        while date < start_of_next_week:
+        while date <= end_date:
             add_meal(date=date, type="lunch")
             add_meal(date=date, type="dinner")
 
-            date += datetime.timedelta(days=1)
-
-
-def start_of_week(date=datetime.date.today()):
-    return date - datetime.timedelta(days=date.weekday() + 1)
+            date = next_day(date)
 
 
 def add_meal(date, type):

--- a/meals/management/commands/seed_meals.py
+++ b/meals/management/commands/seed_meals.py
@@ -10,10 +10,11 @@ class Command(BaseCommand):
     help = 'Inserts test data'
 
     def handle(self, *args, **options):
-        Meal.objects.all().delete()
+        start_of_this_week = start_of_week()
+        start_of_next_week = start_of_this_week + datetime.timedelta(weeks=1)
 
-        date = start_of_week()
-        for _ in range(7):
+        date = start_of_this_week - datetime.timedelta(weeks=1)
+        while date < start_of_next_week:
             add_meal(date=date, type="lunch")
             add_meal(date=date, type="dinner")
 
@@ -25,10 +26,12 @@ def start_of_week(date=datetime.date.today()):
 
 
 def add_meal(date, type):
-    meal = Meal.objects.create(date=date, type=type)
-    add_entre(meal)
-    add_side(meal)
-    add_side(meal)
+    meal, created = Meal.objects.get_or_create(date=date, type=type)
+
+    if created:
+        add_entre(meal)
+        add_side(meal)
+        add_side(meal)
 
 
 def add_entre(meal):

--- a/meals/models.py
+++ b/meals/models.py
@@ -1,5 +1,12 @@
 from django.db import models
 
+from .dates import today, week_range
+
+
+class MealManager(models.Manager):
+    def week_of(self, date=today()):
+        return self.filter(date__range=week_range(date))
+
 
 class Meal(models.Model):
     date = models.DateField(db_index=True)
@@ -18,6 +25,7 @@ class Meal(models.Model):
         auto_now=True,
         editable=False,
     )
+    objects = MealManager()
 
     class Meta:
         unique_together = ['date', 'type']
@@ -25,7 +33,8 @@ class Meal(models.Model):
 
 
 class MealItem(models.Model):
-    meal = models.ForeignKey(Meal, related_name='items', on_delete=models.CASCADE)
+    meal = models.ForeignKey(Meal, related_name='items',
+                             on_delete=models.CASCADE)
     name = models.CharField(max_length=100)
     type = models.CharField(
         choices=[

--- a/meals/models.py
+++ b/meals/models.py
@@ -1,14 +1,11 @@
 from django.db import models
 
-from .dates import today, week_range
+from .dates import week_range
 
 
-class MealManager(models.Manager):
+class MealQuerySet(models.QuerySet):
     def week_of(self, date):
         return self.filter(date__range=week_range(date))
-
-    def current_week(self):
-        return self.week_of(today())
 
 
 class Meal(models.Model):
@@ -28,7 +25,7 @@ class Meal(models.Model):
         auto_now=True,
         editable=False,
     )
-    objects = MealManager()
+    objects = MealQuerySet.as_manager()
 
     class Meta:
         unique_together = ['date', 'type']

--- a/meals/models.py
+++ b/meals/models.py
@@ -4,8 +4,11 @@ from .dates import today, week_range
 
 
 class MealManager(models.Manager):
-    def week_of(self, date=today()):
+    def week_of(self, date):
         return self.filter(date__range=week_range(date))
+
+    def current_week(self):
+        return self.week_of(today())
 
 
 class Meal(models.Model):

--- a/meals/pagination.py
+++ b/meals/pagination.py
@@ -1,0 +1,61 @@
+from collections import OrderedDict
+
+from django.utils import dateparse
+
+from rest_framework.exceptions import NotFound
+from rest_framework.pagination import BasePagination
+from rest_framework.response import Response
+from rest_framework.utils.urls import replace_query_param
+
+from .dates import today, next_week, previous_week
+
+
+class MealPagination(BasePagination):
+    def paginate_queryset(self, queryset, request, view=None):
+        scope = self.get_scope(request)
+        date = self.get_date(request)
+
+        if scope != 'week':
+            raise NotFound
+
+        self.request = request
+        self.scope = scope
+        self.date = date
+
+        return queryset.week_of(date)
+
+    def get_paginated_response(self, data):
+        return Response(OrderedDict([
+            ('next', self.get_next_link()),
+            ('previous', self.get_previous_link()),
+            ('results', data),
+        ]))
+
+    def get_scope(self, request):
+        return request.query_params.get('scope', 'week')
+
+    def get_date(self, request):
+        date_param = request.query_params.get('for_date', None)
+
+        if date_param:
+            return dateparse.parse_date(date_param)
+        else:
+            return today()
+
+    def get_next_link(self):
+        url = self.request.build_absolute_uri()
+        url = replace_query_param(url, 'scope', self.scope)
+        return replace_query_param(url, 'for_date', self.get_next_date())
+
+    def get_previous_link(self):
+        url = self.request.build_absolute_uri()
+        url = replace_query_param(url, 'scope', self.scope)
+        return replace_query_param(url, 'for_date', self.get_previous_date())
+
+    def get_next_date(self):
+        if self.scope == 'week':
+            return next_week(self.date)
+
+    def get_previous_date(self):
+        if self.scope == 'week':
+            return previous_week(self.date)

--- a/meals/urls.py
+++ b/meals/urls.py
@@ -4,7 +4,7 @@ from rest_framework.routers import DefaultRouter
 from meals import views
 
 router = DefaultRouter()
-router.register(r'meals', views.MealViewSet, basename='meal')
+router.register(r'meals', views.MealViewSet)
 
 urlpatterns = [
     path('api/', include(router.urls)),

--- a/meals/urls.py
+++ b/meals/urls.py
@@ -4,7 +4,7 @@ from rest_framework.routers import DefaultRouter
 from meals import views
 
 router = DefaultRouter()
-router.register(r'meals', views.MealViewSet)
+router.register(r'meals', views.MealViewSet, basename='meal')
 
 urlpatterns = [
     path('api/', include(router.urls)),

--- a/meals/views.py
+++ b/meals/views.py
@@ -6,5 +6,5 @@ from .serializers import MealSerializer
 
 
 class MealViewSet(viewsets.ModelViewSet):
-    queryset = Meal.objects.all()
+    queryset = Meal.objects.week_of()
     serializer_class = MealSerializer

--- a/meals/views.py
+++ b/meals/views.py
@@ -1,18 +1,12 @@
 from django.shortcuts import render
-from django.utils import dateparse
 from rest_framework import viewsets
 
 from .models import Meal
+from .pagination import MealPagination
 from .serializers import MealSerializer
 
 
 class MealViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = Meal.objects.all()
     serializer_class = MealSerializer
-
-    def get_queryset(self):
-        date_param = self.request.query_params.get('week_of', None)
-        if date_param:
-            date = dateparse.parse_date(date_param)
-            return Meal.objects.week_of(date)
-        else:
-            return Meal.objects.current_week()
+    pagination_class = MealPagination

--- a/meals/views.py
+++ b/meals/views.py
@@ -1,10 +1,18 @@
 from django.shortcuts import render
+from django.utils import dateparse
 from rest_framework import viewsets
 
 from .models import Meal
 from .serializers import MealSerializer
 
 
-class MealViewSet(viewsets.ModelViewSet):
-    queryset = Meal.objects.week_of()
+class MealViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = MealSerializer
+
+    def get_queryset(self):
+        date_param = self.request.query_params.get('week_of', None)
+        if date_param:
+            date = dateparse.parse_date(date_param)
+            return Meal.objects.week_of(date)
+        else:
+            return Meal.objects.current_week()

--- a/menu_planner/settings.py
+++ b/menu_planner/settings.py
@@ -107,7 +107,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'America/Indianapolis'
 
 USE_I18N = True
 


### PR DESCRIPTION
* Added `dates` module to allow for reuse of common date related functions
* Updated seeds script to _not_ delete all meals each time. It will also create meals for the previous week in addition to the current week
* Added a custom queryset filter to the Meal model to support retrieving meals for a week, given a specific date
* Added a custom pagination module which will filter meals to a given scope (currently just week) and provide `next` and `previous` links
* Updated the MealViewSet to be read-only and to use the new pagination
* Set the application time zone

![image](https://user-images.githubusercontent.com/3910847/111075206-3d79a600-84bd-11eb-8ad3-1ade7f1d67dc.png)

## Resources
**Custom Pagination**
* https://www.django-rest-framework.org/api-guide/pagination/#custom-pagination-styles

**Custom QuerySet**
* https://simpleisbetterthancomplex.com/tips/2016/08/16/django-tip-11-custom-manager-with-chainable-querysets.html

**DRF Pagination Source Code**
* https://github.com/encode/django-rest-framework/blob/master/rest_framework/pagination.py